### PR TITLE
 update shared workflow actions to v7.0.0 and bump R base image to 1.19.0

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,4 +16,4 @@ jobs:
     if: github.event.repository.private == false
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-dependency-review.yml@9fbe4cbba23d4a768eb36462458a4cfcb63682e1 # v5.2.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-dependency-review.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-release-container.yml@9fbe4cbba23d4a768eb36462458a4cfcb63682e1 # v5.2.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-release-container.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0

--- a/.github/workflows/scan-container.yml
+++ b/.github/workflows/scan-container.yml
@@ -15,6 +15,7 @@ jobs:
       id-token: write
       pull-requests: write
       actions: read
+      security-events: write
     uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0
     with:
       runtime: r

--- a/.github/workflows/scan-container.yml
+++ b/.github/workflows/scan-container.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@9fbe4cbba23d4a768eb36462458a4cfcb63682e1 # v5.2.0
+      actions: read
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0
     with:
       runtime: r

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -14,4 +14,4 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-test-container.yml@9fbe4cbba23d4a768eb36462458a4cfcb63682e1 # v5.2.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-test-container.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/analytical-platform-airflow-r-base:1.18.0@sha256:8caa77b3925e018aef48da5247fb729d83386ce2ca5c43c2b3810c0b6193b0a0
+FROM ghcr.io/ministryofjustice/analytical-platform-airflow-r-base:1.19.0@sha256:f2e58eb695f5d11148ed6b0724f667b4d808f6c07af6d97f4f0cbb9d97bb7a3a
 
 ARG MOJAP_IMAGE_VERSION="default"
 ENV MOJAP_IMAGE_VERSION=${MOJAP_IMAGE_VERSION}


### PR DESCRIPTION
- Bump ministryofjustice/analytical-platform-airflow-github-actions references from `v5.2.0 (9fbe4cb)` to `v7.0.0 (613a7cc)` across dependency-review, release-container, scan-container, and test-container workflows
- Add actions:read and `security-events:write` permissions to `scan-container.yml`, required by the updated shared-scan-container workflow
- Update `Dockerfile` base image to `analytical-platform-airflow-r-base:1.19.0` with new digest

PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/484) ticket.